### PR TITLE
feat: group circleci/node as Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Renovate fetches it from npm registry automatically.
       {
         "groupName": "Node Docker digests in CircleCI",
         "packageNames": [
+          "circleci/node",
           "node"
         ]
       }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
           {
             "groupName": "Node Docker digests in CircleCI",
             "packageNames": [
+              "circleci/node",
               "node"
             ]
           }


### PR DESCRIPTION
Some repos received noisy changes for each Node version (ex. https://github.com/kintone/create-plugin/commit/0e8184032273a1b95bcf8255512ca67d52a6f2ba) because they used `circleci/node` image, not official `node` image.
Currently this config groups only `node` (ex. https://github.com/kintone/plugin-packer/commit/fc21447064a63ab9b1514343469ebba8cfe115b0).

This PR adds `circleci/node` to the Node group.

cc: @koba04