### PR TITLE
feat: change schedule of lock file maintenance to before 5am

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Renovate fetches it from npm registry automatically.
 
 #### for lock file maintenance
 
-- Run following schedule: every weekend and before 9am on Monday
+- Run following schedule: before 5am on the first day of the month
 
 #### for Docker digests in CirleCI config.yml
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
       "lockFileMaintenance": {
         "enabled": true,
         "schedule": [
-          "before 9am on the first day of the month"
+          "before 5am on the first day of the month"
         ]
       },
       "circleci": {


### PR DESCRIPTION
Mitigate multiple runs: https://github.com/renovatebot/config-help/issues/156